### PR TITLE
feat: add split and stats commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,18 @@
    - `--threads` *(default `1`)*: Thread count (reserved for future parallelism).
 
    The command fetches games, mines one mistake-based puzzle per matching game, deduplicates puzzles, samples up to 1000 of them, and writes `pack_<ECO>_v1.zip` into the specified output directory.
+
+## Split & Stats
+
+Split a large PGN dump into per-ECO NDJSON files:
+
+```
+npm run build
+node dist/cli.js split --pgn raw/lichess_db_standard_rated_2025-01.pgn.zst --out packs
+```
+
+Then view counts of games per ECO:
+
+```
+node dist/cli.js stats --dir packs
+```

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "type": "module",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "vitest run"
+    "test": "vitest run",
+    "split": "node dist/cli.js split",
+    "stats": "node dist/cli.js stats"
   },
   "dependencies": {
     "chess.js": "^1.0.0",
@@ -15,6 +17,7 @@
   "devDependencies": {
     "@types/node": "^20.11.0",
     "@types/yargs": "^17.0.33",
+    "pgn-extract": "^22.2.0",
     "tsx": "^4.20.3",
     "typescript": "^5.4.0",
     "vitest": "^1.4.0"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,8 @@ import { mineMistakes } from './mineMistakes.js'
 import { dedupe } from './dedupe.js'
 import { sample } from './sample.js'
 import { pack } from './packer.js'
+import { splitByEco } from './splitByEco.js'
+import { stats } from './stats.js'
 
 export async function main(argv = hideBin(process.argv)) {
   await yargs(argv)
@@ -19,6 +21,19 @@ export async function main(argv = hideBin(process.argv)) {
       const games = fetchGames(args.source as string, args.maxGames as number)
       const puzzles = await sample(dedupe(mineMistakes(games, args.eco as string)), 1000)
       await pack(args.out as string, args.eco as string, puzzles)
+    })
+    .command('split', 'split PGN by ECO', (y: any) => y
+      .option('pgn', { type: 'string', demandOption: true })
+      .option('out', { type: 'string', default: 'packs' })
+      .option('ecoPrefix', { type: 'string' })
+      .option('limit', { type: 'number', default: 0 })
+    , async (argv: any) => {
+      await splitByEco(argv)
+    })
+    .command('stats', 'show stats for packs', (y: any) => y
+      .option('dir', { type: 'string', default: 'packs' })
+    , async (argv: any) => {
+      await stats(argv)
     })
     .demandCommand(1)
     .help()

--- a/src/splitByEco.ts
+++ b/src/splitByEco.ts
@@ -1,0 +1,95 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import readline from 'node:readline'
+import { spawnPipeline } from './util/stream.js'
+
+interface Opts {
+  pgn: string
+  out: string
+  ecoPrefix?: string
+  limit: number
+}
+
+export async function splitByEco(opts: Opts): Promise<void> {
+  const { pgn, out, ecoPrefix, limit } = opts
+  const start = Date.now()
+  await fs.promises.mkdir(out, { recursive: true })
+  const writers: Record<string, fs.WriteStream> = {}
+  const counts: Record<string, number> = {}
+  let total = 0
+
+  const ensureWriter = (eco: string) => {
+    if (!writers[eco]) {
+      const file = path.join(out, `${eco}.ndjson`)
+      writers[eco] = fs.createWriteStream(file, { flags: 'a' })
+      counts[eco] = 0
+    }
+    return writers[eco]
+  }
+
+  const closeAll = () => {
+    for (const w of Object.values(writers)) w.end()
+  }
+
+  process.on('SIGINT', () => {
+    closeAll()
+    process.exit(0)
+  })
+
+  let stream: NodeJS.ReadableStream
+  if (pgn === '-') {
+    const proc = spawnPipeline([
+      ['npx', ['pgn-extract', '--fen', '--json', '--opening', '-']]
+    ])
+    process.stdin.pipe(proc.stdin!)
+    stream = proc.stdout!
+  } else {
+    const cmds: [string, string[]][] = []
+    if (pgn.endsWith('.zst')) cmds.push(['zstdcat', [pgn]])
+    else cmds.push(['cat', [pgn]])
+    cmds.push(['npx', ['pgn-extract', '--fen', '--json', '--opening', '-']])
+    const proc = spawnPipeline(cmds)
+    stream = proc.stdout!
+  }
+
+  const rl = readline.createInterface({ input: stream })
+
+  for await (const line of rl) {
+    if (!line) continue
+    const obj = JSON.parse(line)
+    const eco = obj?.opening?.eco
+    if (!eco) continue
+    if (ecoPrefix && !eco.startsWith(ecoPrefix)) continue
+    ensureWriter(eco).write(line + '\n')
+    counts[eco]++
+    total++
+    if (total % 1000 === 0) {
+      console.log(
+        Object.entries(counts)
+          .map(([e, c]) => `${e}: ${c.toLocaleString()}`)
+          .join('  |  ')
+      )
+    }
+    if (limit && total >= limit) break
+  }
+
+  closeAll()
+
+  const duration = Date.now() - start
+  const mins = Math.floor(duration / 60000)
+  const secs = Math.floor((duration % 60000) / 1000)
+  const files = Object.keys(counts).length
+  let largestEco = ''
+  let largest = 0
+  for (const [e, c] of Object.entries(counts)) {
+    if (c > largest) {
+      largestEco = e
+      largest = c
+    }
+  }
+  console.log(`Split complete  (${mins} min ${secs} s) `)
+  console.log(`files written:  ${files}`)
+  console.log(`total games:    ${total.toLocaleString()}`)
+  if (largestEco)
+    console.log(`largest file:   ${largestEco}.ndjson (${largest.toLocaleString()} games)`)
+}

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -1,0 +1,25 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { lineCounter } from './util/stream.js'
+
+interface Opts {
+  dir: string
+}
+
+export async function stats(opts: Opts): Promise<void> {
+  const dir = opts.dir
+  const files = (await fs.promises.readdir(dir)).filter(f => f.endsWith('.ndjson'))
+  const rows: { eco: string; count: number }[] = []
+  let total = 0
+  for (const file of files) {
+    const count = await lineCounter(fs.createReadStream(path.join(dir, file)))
+    rows.push({ eco: path.basename(file, '.ndjson'), count })
+    total += count
+  }
+  rows.sort((a, b) => b.count - a.count)
+  console.log('ECO   games')
+  for (const r of rows) {
+    console.log(`${r.eco.padEnd(4)} ${r.count.toLocaleString()}`)
+  }
+  console.log(`Total ${total.toLocaleString()}   files:${files.length}`)
+}

--- a/src/util/stream.ts
+++ b/src/util/stream.ts
@@ -1,0 +1,21 @@
+import { execa, ExecaChildProcess } from 'execa'
+import { Readable } from 'node:stream'
+import readline from 'node:readline'
+
+export function spawnPipeline(cmds: [string, string[]][]): ExecaChildProcess {
+  let proc = execa(cmds[0][0], cmds[0][1], { stdout: 'pipe' })
+  let current = proc
+  for (const [cmd, args] of cmds.slice(1)) {
+    const next = execa(cmd, args, { stdin: 'pipe', stdout: 'pipe' })
+    current.stdout!.pipe(next.stdin!)
+    current = next
+  }
+  return current
+}
+
+export async function lineCounter(stream: Readable): Promise<number> {
+  const rl = readline.createInterface({ input: stream })
+  let count = 0
+  for await (const _ of rl) count++
+  return count
+}

--- a/test/fixtures/a00_test.pgn
+++ b/test/fixtures/a00_test.pgn
@@ -1,0 +1,10 @@
+[Event "Test"]
+[Site "?"]
+[Date "2020.01.01"]
+[Round "1"]
+[White "White"]
+[Black "Black"]
+[Result "*"]
+[ECO "A00"]
+
+1. e4 e5 *

--- a/test/split.test.ts
+++ b/test/split.test.ts
@@ -1,0 +1,15 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { tmpdir } from 'node:os'
+import { describe, it, expect } from 'vitest'
+import { splitByEco } from '../src/splitByEco.js'
+
+describe('splitByEco', () => {
+  it('splits PGN into ECO files', async () => {
+    const dir = fs.mkdtempSync(path.join(tmpdir(), 'packs-'))
+    await splitByEco({ pgn: 'test/fixtures/a00_test.pgn', out: dir, limit: 0 })
+    const file = path.join(dir, 'A00.ndjson')
+    const lines = fs.readFileSync(file, 'utf8').trim().split('\n')
+    expect(lines.length).toBeGreaterThan(0)
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,11 +3,12 @@
     "target": "ES2022",
     "module": "ES2022",
     "moduleResolution": "node",
+    "rootDir": "src",
     "outDir": "dist",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "strict": true
   },
-  "include": ["src/**/*", "test/**/*"]
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Summary
- add stream helpers for pipelines and counting
- implement `split` to write per-ECO ndjson files
- add `stats` to report game counts

## Testing
- `npm run build`
- `node dist/cli.js split --pgn test/fixtures/a00_test.pgn --out packs` *(no games output; missing `pgn-extract`)*
- `node dist/cli.js stats --dir packs`
- `npm test` *(fails: ENOENT because `pgn-extract` binary not found)*

------
https://chatgpt.com/codex/tasks/task_e_68946266e51c832d8cd33a07c5887ea9