### PR TITLE
feat: add native stockfish engine option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,16 @@ node dist/cli.js eval \
 ```
 
 Each game is evaluated until the first ≥200 cp swing (or mate) and written as one line of NDJSON. Games without such a swing in the first 40 plies are skipped. The resulting file can be supplied to `make` via `--source`.
+
+To use a native Stockfish binary instead of the default WASM build:
+
+```
+node dist/cli.js eval \
+  --engine native \
+  --pgn packs/B90.pgn \
+  --out packs/B90.ndjson \
+  --depth 17 \
+  --threads 1
+```
+
+Ensure the `stockfish` executable is available on your `PATH` (for example, `brew install stockfish` on macOS).

--- a/src/annotateGame.ts
+++ b/src/annotateGame.ts
@@ -1,25 +1,64 @@
 import { Chess } from 'chess.js'
 import { createHash } from 'node:crypto'
 import type Piscina from 'piscina'
+import type { ChildProcessWithoutNullStreams } from 'node:child_process'
 import type { Game } from './streamPgn.js'
+
+export type Engine =
+  | { type: 'wasm'; pool: Piscina }
+  | { type: 'native'; proc: ChildProcessWithoutNullStreams }
+
+async function evaluateNative(
+  proc: ChildProcessWithoutNullStreams,
+  fen: string,
+  depth: number
+): Promise<{ score: number; best: string }> {
+  return new Promise(resolve => {
+    let best = ''
+    let score = 0
+    const onData = (data: Buffer) => {
+      for (const line of data.toString().split('\n')) {
+        const m = line.match(/score (cp|mate) (-?\d+)/)
+        if (m) {
+          const type = m[1]
+          const val = parseInt(m[2], 10)
+          score = type === 'cp' ? val : val > 0 ? 30000 - val : -30000 - val
+        }
+        if (line.startsWith('bestmove')) {
+          best = line.split(' ')[1]
+          proc.stdout.off('data', onData)
+          resolve({ score, best })
+        }
+      }
+    }
+    proc.stdout.on('data', onData)
+    proc.stdin.write(`ucinewgame\nposition fen ${fen}\ngo depth ${depth}\n`)
+  })
+}
 
 export async function annotate(
   game: Game,
   depth: number,
-  pool: Piscina
+  engine: Engine
 ): Promise<Record<string, any> | null> {
   const chess = new Chess()
   const analysis: any[] = []
-  let prev = await pool.run({ fen: chess.fen(), depth }, { name: 'evaluate' })
+
+  const evaluate = (fen: string) =>
+    engine.type === 'wasm'
+      ? (engine.pool.run({ fen, depth }, { name: 'evaluate' }) as Promise<{
+          score: number
+          best: string
+        }>)
+      : evaluateNative(engine.proc, fen, depth)
+
+  let prev = await evaluate(chess.fen())
   let found = false
 
   for (let i = 0; i < game.moves.length && i < 40; i++) {
     const move = game.moves[i]
     chess.move(move)
-    const cur = await pool.run(
-      { fen: chess.fen(), depth },
-      { name: 'evaluate' }
-    )
+    const cur = await evaluate(chess.fen())
     analysis.push({ eval: cur.score, best: cur.best })
     const swing = Math.abs(prev.score - cur.score)
     if (

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,6 +36,11 @@ export async function main(argv = hideBin(process.argv)) {
       .option('out', { type: 'string', demandOption: true })
       .option('depth', { type: 'number', default: 12 })
       .option('threads', { type: 'number', default: 1 })
+      .option('engine', {
+        type: 'string',
+        choices: ['wasm', 'native'],
+        default: 'wasm'
+      })
     , async (argv: any) => {
       await evalCmd(argv)
     })

--- a/src/evalCmd.ts
+++ b/src/evalCmd.ts
@@ -1,24 +1,54 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
 import Piscina from 'piscina'
 import { streamPgn } from './streamPgn.js'
-import { annotate } from './annotateGame.js'
+import { annotate, type Engine } from './annotateGame.js'
 
 interface Opts {
   pgn: string
   out: string
   depth: number
   threads: number
+  engine: 'wasm' | 'native'
 }
 
 export async function run(opts: Opts): Promise<void> {
-  const { pgn, out, depth, threads } = opts
+  const { pgn, out, depth, threads, engine } = opts
   await fs.promises.mkdir(path.dirname(out), { recursive: true })
   const outStream = fs.createWriteStream(out)
-  const pool = new Piscina({
-    filename: new URL('./stockfishWorker.js', import.meta.url).pathname,
-    maxThreads: threads
-  })
+
+  let handle: Engine
+  if (engine === 'wasm') {
+    const pool = new Piscina({
+      filename: new URL('./stockfishWorker.js', import.meta.url).pathname,
+      maxThreads: threads
+    })
+    handle = { type: 'wasm', pool }
+  } else {
+    const proc: ChildProcessWithoutNullStreams = spawn('stockfish')
+    proc.on('error', () => {
+      console.error("native engine 'stockfish' not found on PATH—please install it.")
+      process.exit(1)
+    })
+    const ready = new Promise<void>(resolve => {
+      const onData = (data: Buffer) => {
+        if (data.toString().includes('uciok')) {
+          proc.stdout.off('data', onData)
+          resolve()
+        }
+      }
+      proc.stdout.on('data', onData)
+    })
+    proc.stdin.write('uci\n')
+    await ready
+    proc.stdin.write(`setoption name Threads value ${threads}\n`)
+    handle = { type: 'native', proc }
+    process.on('SIGINT', () => {
+      proc.kill()
+      process.exit(1)
+    })
+  }
 
   let scanned = 0
   let written = 0
@@ -33,7 +63,7 @@ export async function run(opts: Opts): Promise<void> {
 
   for await (const game of streamPgn(pgn)) {
     scanned++
-    const obj = await annotate(game, depth, pool)
+    const obj = await annotate(game, depth, handle)
     if (obj) {
       outStream.write(JSON.stringify(obj) + '\n')
       written++
@@ -42,8 +72,10 @@ export async function run(opts: Opts): Promise<void> {
 
   clearInterval(timer)
   outStream.end()
+  if (handle.type === 'native') handle.proc.kill()
+  else await handle.pool.destroy()
   const duration = (Date.now() - start) / 1000
-  console.log(`\ncompleted in ${duration.toFixed(1)}s`) 
+  console.log(`\ncompleted in ${duration.toFixed(1)}s`)
   console.log(`games scanned: ${scanned}`)
   console.log(`files written: ${written}`)
 }


### PR DESCRIPTION
## Summary
- add `--engine` flag for selecting wasm or native stockfish
- spawn local stockfish binary when `--engine native` and evaluate positions
- document native engine usage and requirement in README

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689496096898832db28c8918cbc744cb