### PR TITLE
Wire up native Stockfish engine

### DIFF
--- a/src/evalCmd.ts
+++ b/src/evalCmd.ts
@@ -26,9 +26,18 @@ export async function run(opts: Opts): Promise<void> {
     })
     handle = { type: 'wasm', pool }
   } else {
-    const proc: ChildProcessWithoutNullStreams = spawn('stockfish')
+    const env = {
+      ...process.env,
+      PATH: `${process.env.PATH ?? ''}:/usr/games`
+    }
+    const proc: ChildProcessWithoutNullStreams = spawn(
+      process.env.STOCKFISH_PATH ?? 'stockfish',
+      { env }
+    )
     proc.on('error', () => {
-      console.error("native engine 'stockfish' not found on PATH—please install it.")
+      console.error(
+        "native engine 'stockfish' not found on PATH—please install it."
+      )
       process.exit(1)
     })
     const ready = new Promise<void>(resolve => {


### PR DESCRIPTION
## Summary
- allow the `eval` command to run the native Stockfish binary by resolving `stockfish` through PATH or `STOCKFISH_PATH`

## Testing
- `npm run build`
- `npm test`
- `PATH=$PATH:/usr/games node dist/cli.js eval --engine native --pgn packs/test.pgn --out packs/test.ndjson --depth 12 --threads 1`

------
https://chatgpt.com/codex/tasks/task_e_689499a7c83c832d87384ed4315ebc22