### PR TITLE
Use annotate() for eval CLI output

### DIFF
--- a/src/annotateGame.ts
+++ b/src/annotateGame.ts
@@ -80,11 +80,20 @@ export async function annotate(
     .update(JSON.stringify(headers) + game.moves.join(' '))
     .digest('hex')
 
+  const dateStr = headers.UTCDate || headers.Date || ''
+  const timeStr = headers.UTCTime || headers.Time || '00:00:00'
+  let createdAt = Date.parse(
+    `${dateStr.replace(/\./g, '-')}T${timeStr.replace(/\./g, ':')}Z`
+  )
+  if (Number.isNaN(createdAt)) createdAt = Date.now()
+
   return {
     id,
+    createdAt,
     opening: {
       eco: headers.ECO,
-      name: headers.Opening
+      name: headers.Opening,
+      variation: headers.Variation
     },
     moves: game.moves.join(' '),
     analysis


### PR DESCRIPTION
## Summary
- use `annotate()` when evaluating PGNs so NDJSON includes judgments
- enrich annotations with creation time and opening variation metadata

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894c97eeba8832d8870505e83fe1954